### PR TITLE
PSL-294: support clean in update command

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -353,7 +353,7 @@ func runUpdateWalletNodeSubCommand(ctx context.Context, config *configs.Config) 
 }
 
 func stopAndUpdateService(ctx context.Context, service constants.ToolType, config *configs.Config) error {
-	servicesToStop := updateServicesToStop[constants.WalletNode]
+	servicesToStop := updateServicesToStop[service]
 	err := stopServicesWithConfirmation(ctx, config, servicesToStop)
 	if err != nil {
 		log.WithContext(ctx).WithError(err).Error("Failed to stop dependent services")
@@ -363,7 +363,7 @@ func stopAndUpdateService(ctx context.Context, service constants.ToolType, confi
 	if err != nil {
 		return err
 	}
-	servicesToUpdate := updateDependencies[constants.WalletNode]
+	servicesToUpdate := updateDependencies[service]
 	for _, service := range servicesToUpdate {
 		err = updateService(ctx, config, service)
 		if err != nil {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -447,14 +447,11 @@ func archiveWorkDir(ctx context.Context, config *configs.Config) error {
 	if config.Clean {
 		pathToClean := path.Join(homeDir, workDir)
 		log.WithContext(ctx).Infof("Clean flag set, cleaning work dir (%v)", pathToClean)
-		files, err := ioutil.ReadDir(pathToClean)
+		filesToPreserve := []string{"pastel.conf", "wallet.dat", "masternode.conf"}
+		err = utils.ClearDir(ctx, pathToClean, filesToPreserve)
 		if err != nil {
-			log.WithContext(ctx).Errorf("Failed to read directory files: %v", err)
+			log.WithContext(ctx).Error(fmt.Sprintf("Failed to clean directory:  %v", err))
 			return err
-		}
-
-		for _, file := range files {
-			log.WithContext(ctx).Infof("File=%v, isDir=%v", file.Name(), file.IsDir())
 		}
 	}
 	log.WithContext(ctx).Info(fmt.Sprintf("Archived %v directory as %v", dirToArchive, archiveName))

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -447,10 +447,14 @@ func archiveWorkDir(ctx context.Context, config *configs.Config) error {
 	if config.Clean {
 		pathToClean := path.Join(homeDir, workDir)
 		log.WithContext(ctx).Infof("Clean flag set, cleaning work dir (%v)", pathToClean)
-		cleanCmd := fmt.Sprintf("rm %v -v !(\"pastel.conf\"|\"wallet.dat\"|\"masternode.conf\")", pathToClean)
-		_, err := RunCMD("bash", "-c", cleanCmd)
+		files, err := ioutil.ReadDir(pathToClean)
 		if err != nil {
+			log.WithContext(ctx).Errorf("Failed to read directory files: %v", err)
 			return err
+		}
+
+		for _, file := range files {
+			log.WithContext(ctx).Infof("File=%v, isDir=%v", file.Name(), file.IsDir())
 		}
 	}
 	log.WithContext(ctx).Info(fmt.Sprintf("Archived %v directory as %v", dirToArchive, archiveName))

--- a/configs/init.go
+++ b/configs/init.go
@@ -8,6 +8,7 @@ type Init struct {
 	RPCUser          string `json:"rpc-user,omitempty"`
 	RPCPwd           string `json:"rpc-pwd,omitempty"`
 	Force            bool   `json:"force,omitempty"`
+	Clean            bool   `json:"clean,omitempty"`
 	Peers            string `json:"peers"`
 	PastelExecDir    string `json:"pastelexecdir,omitempty"`
 	Version          string `json:"nodeversion,omitempty"`

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -29,7 +29,6 @@ import (
 	"golang.org/x/term"
 
 	"github.com/dustin/go-humanize"
-	"github.com/kickback-app/api/utils"
 	"github.com/pastelnetwork/gonode/common/log"
 	"github.com/pastelnetwork/pastelup/constants"
 	"github.com/pkg/errors"
@@ -594,7 +593,7 @@ func ClearDir(ctx context.Context, dir string, skipFiles []string) error {
 		return err
 	}
 	for _, file := range files {
-		if !utils.Contains(skipFiles, file.Name()) {
+		if !Contains(skipFiles, file.Name()) {
 			if file.IsDir() {
 				err = ClearDir(ctx, path.Join(dir, file.Name()), []string{})
 				if err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -586,6 +586,9 @@ func GetExternalIPAddress() (externalIP string, err error) {
 	return string(body), nil
 }
 
+// ClearDir removes all contents in the provided directory unless they are in the skipFiles array.
+// this recursively calls itself to clear out files in subdirs.
+// skipFiles only works for top-level files in the original dir provided, it doesnt get applied to subdirs.
 func ClearDir(ctx context.Context, dir string, skipFiles []string) error {
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {


### PR DESCRIPTION
https://pastel-network.atlassian.net/browse/PSL-294

+ I moved the redudant code in `runUpdateWalletNodeSubCommand`,  `runUpdateNodeSubCommand` & `runUpdateSuperNodeSubCommand` into a function and just invoked it from those parent funcs.