### PR TITLE
require release version to be explicitly set on update and install

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -85,7 +85,7 @@ func setupSubCommand(config *configs.Config,
 		cli.NewFlag("force", &config.Force).SetAliases("f").
 			SetUsage(green("Optional, Force to overwrite config files and re-download ZKSnark parameters")),
 		cli.NewFlag("release", &config.Version).SetAliases("r").
-			SetUsage(green("Optional, Pastel version to install")).SetValue("beta"),
+			SetUsage(green("Optional, Pastel version to install")),
 		cli.NewFlag("enable-service", &config.EnableService).
 			SetUsage(green("Optional, start all apps automatically as system service (i.e. for linux OS, systemd)")),
 	}
@@ -182,7 +182,13 @@ func setupSubCommand(config *configs.Config,
 				os.Exit(0)
 			})
 
-			log.WithContext(ctx).Info("Started")
+			if config.Version == "" {
+				log.WithContext(ctx).
+					WithError(constants.NoVersionSetErr{}).
+					Error("Failed to process install command")
+				return err
+			}
+			log.WithContext(ctx).Infof("Started install...release set to '%v' ", config.Version)
 			if err = f(ctx, config); err != nil {
 				return err
 			}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -65,7 +65,7 @@ func setupUpdateSubCommand(config *configs.Config,
 		cli.NewFlag("peers", &config.Peers).SetAliases("p").
 			SetUsage(green("Optional, List of peers to add into pastel.conf file, must be in the format - \"ip\" or \"ip:port\"")),
 		cli.NewFlag("release", &config.Version).SetAliases("r").
-			SetUsage(green("Optional, Pastel version to install")).SetValue("beta"),
+			SetUsage(green("Optional, Pastel version to install")),
 		cli.NewFlag("clean", &config.Clean).SetAliases("c").
 			SetUsage(green("Optional, Clean .pastel folder")),
 		cli.NewFlag("user-pw", &config.UserPw).
@@ -144,7 +144,13 @@ func setupUpdateSubCommand(config *configs.Config,
 				os.Exit(0)
 			})
 
-			log.WithContext(ctx).Info("Started")
+			if config.Version == "" {
+				log.WithContext(ctx).
+					WithError(constants.NoVersionSetErr{}).
+					Error("Failed to process update command")
+				return err
+			}
+			log.WithContext(ctx).Infof("Started update...release set to '%v' ", config.Version)
 			if err = f(ctx, config); err != nil {
 				return err
 			}

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -351,3 +351,14 @@ var NetworkModes = []string{
 	NetworkTestnet,
 	NetworkRegTest,
 }
+
+type NoVersionSetErr struct{}
+
+func (e NoVersionSetErr) Error() string {
+	return `
+--release or -r must be provided. Recommened to use 'beta' i.e.
+	
+	pastelup install <service> -r beta
+	
+More information can be found: https://download.pastel.network/#"`
+}

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -352,6 +352,8 @@ var NetworkModes = []string{
 	NetworkRegTest,
 }
 
+// NoVersionSetErr is an error returned if a install or update command is initiated without
+// explicitly providing the requested version parameter
 type NoVersionSetErr struct{}
 
 func (e NoVersionSetErr) Error() string {


### PR DESCRIPTION
https://pastel-network.atlassian.net/browse/PSL-344

--> should we validate what the user provided release is? can it only be a subset of values? if so, which other values past `beta` and `latest`