### PR TITLE
[PSL-1264] add optional snapshot name flag support for install command

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -96,6 +96,8 @@ func setupUpdateSubCommand(config *configs.Config,
 			SetUsage(green("Optional, Skip Download and Update of dd-service supporting files")).SetValue(true),
 		cli.NewFlag("use-snapshot", &config.UseSnapshot).SetAliases("us").
 			SetUsage(green("Optional, Set to true if want to update with latest snapshot")),
+		cli.NewFlag("snapshot-name", &config.SnapshotName).SetAliases("sn").
+			SetUsage(green("Optional, Set the specific snapshot name to install with")),
 	}
 
 	userFlags := []*cli.Flag{

--- a/configs/init.go
+++ b/configs/init.go
@@ -34,6 +34,7 @@ type Init struct {
 	ServiceSolution             string `json:"solution,omitempty"`
 	DevMode                     bool   `json:"devmode,omitempty"`
 	UseSnapshot                 bool   `json:"use-snapshot,omitempty"`
+	SnapshotName                string `json:"snapshot-name,omitempty"`
 
 	NodeExtIP string `json:"nodeextip,omitempty"`
 


### PR DESCRIPTION
Since we have different snapshots, for differently configured nodes, a new flag has been added `snapshot-name` that can be used with the `use-snapshot` flag to explicitly define the snapshot name, otherwise if `snapshot-name` is not provided, It will start with the latest snapshot.