### PR TITLE
[PSL-1265] implement changes to get latest snapshots during installation

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -1805,7 +1805,10 @@ func getLatestFileURL(baseURL string, fileName string) (string, error) {
 		date time.Time
 	}
 
-	var files []fileInfo
+	var (
+		files       []fileInfo
+		latestFiles []fileInfo
+	)
 	re := regexp.MustCompile(`.*\.(tar\.(gz|zst)|7z)$`)
 
 	// Iterate over each row in the table
@@ -1840,6 +1843,18 @@ func getLatestFileURL(baseURL string, fileName string) (string, error) {
 				return f.url, nil
 			}
 		}
+	} else {
+		for _, f := range files {
+			if strings.Contains(f.url, "latest") {
+				log.WithContext(ctx).WithField("url", f.url).Debug("found a snapshot with latest keyword")
+				latestFiles = append(latestFiles, fileInfo{url: f.url, date: f.date})
+			}
+		}
+	}
+
+	if len(latestFiles) != 0 {
+		files = make([]fileInfo, len(latestFiles))
+		copy(files, latestFiles)
 	}
 
 	// Sort files by date, latest first


### PR DESCRIPTION
This PR updates the logic for fetching the latest snapshots using the `latest` keyword.

Previously, pastelup selected the latest snapshot based on the `date_modified` column.

Now, it first looks for snapshots with `latest` in their names and picks the most recent one based on `date_modified`. If no snapshots with `latest` are found, it falls back to selecting the most recent one by `date_modified`